### PR TITLE
Webhook: Fix edición

### DIFF
--- a/src/app/webhook/components/webhook.component.ts
+++ b/src/app/webhook/components/webhook.component.ts
@@ -77,6 +77,8 @@ export class WebHookComponent implements OnInit {
         } else {
             this.webhookService.patch(webhook.id, webhook).subscribe(resultado => {
                 this.plex.info('info', 'El webhook fue editado');
+                this.webHook.method = '';
+                this.filtrarPorNombre(webhook.name);
             });
         }
     }


### PR DESCRIPTION
### Requerimiento
Al editar un webhook y hacer click nuevamente en el botón editar del mismo, no abre el sidebar

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Al finalizar la edicion de un webhook se llama a la función filtrar con su nombre como parametro


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

