### PR TITLE
Modulos: no importar lazy load modules

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,4 +1,3 @@
-import { LoginModule } from './login/login.module';
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
@@ -27,9 +26,6 @@ import { OrganizacionService } from './services/organizacion.service';
 import { SendMessageCacheService } from './monitor-activaciones/services/sendMessageCache.service';
 import { WebhookLogComponent } from './webhook-log/webhook-log.component';
 import { WebhookLogService } from './webhook-log/services/webhook-log.service';
-import { QueriesModule } from './queries/queries.module';
-import { CdaModule } from './cda/cda.module';
-import { NovedadesModule } from './registro-novedades/novedades.module';
 import { ModulosService } from './modulos/services/modulos.service';
 import { ModulosModule } from './modulos/modulos.module';
 
@@ -53,10 +49,6 @@ import { ModulosModule } from './modulos/modulos.module';
     routing,
     AuthModule,
     InfiniteScrollModule,
-    QueriesModule,
-    CdaModule,
-    NovedadesModule,
-    LoginModule,
     ModulosModule
   ],
   providers: [

--- a/src/app/cda/cda-routing.module.ts
+++ b/src/app/cda/cda-routing.module.ts
@@ -5,7 +5,7 @@ import { RoutingGuard } from '../login/routing-guard';
 import { CdaRegenerarComponent } from './components/cda-regenerar.component';
 
 const routes = [
-    { path: 'cda-regenerar', component: CdaRegenerarComponent, canActivate: [RoutingGuard] }
+    { path: '', component: CdaRegenerarComponent, canActivate: [RoutingGuard] }
 ];
 
 @NgModule({

--- a/src/app/queries/queries-routing.module.ts
+++ b/src/app/queries/queries-routing.module.ts
@@ -4,7 +4,7 @@ import { RoutingGuard } from '../login/routing-guard';
 import { QueryExecuteComponent } from '../queries/componentes/query-execute.component';
 
 const routes = [
-    { path: 'queries', component: QueryExecuteComponent, canActivate: [RoutingGuard] }
+    { path: '', component: QueryExecuteComponent, canActivate: [RoutingGuard] }
 ];
 
 @NgModule({

--- a/src/app/registro-novedades/novedades-routing.module.ts
+++ b/src/app/registro-novedades/novedades-routing.module.ts
@@ -5,7 +5,7 @@ import { RoutingGuard } from '../login/routing-guard';
 import { NovedadesComponent } from './components/novedades.component';
 
 const routes = [
-    { path: 'novedades', component: NovedadesComponent, canActivate: [RoutingGuard] }
+    { path: '', component: NovedadesComponent, canActivate: [RoutingGuard] }
 ];
 
 @NgModule({


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/MONIT-36

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se eliminaron del _app.module_ los módulos que tenían lazy loading para que la funcionalidad tenga efecto.
2. Se modificaron las rutas en cada modulo para que sigan funcionando correctamente.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

![Captura de pantalla -2020-06-25 09-03-31](https://user-images.githubusercontent.com/56874534/85718002-75895080-b6c4-11ea-8c1f-62528d75e579.png)

